### PR TITLE
ENT-6267 Signature verification bypass fix for RequestKeyFlow

### DIFF
--- a/workflows/src/main/kotlin/com/r3/corda/lib/ci/workflows/RequestKeyFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/ci/workflows/RequestKeyFlow.kt
@@ -94,6 +94,11 @@ private constructor(
         val signedKeyForAccount = session.sendAndReceive<SignedKeyForAccount>(requestKey).unwrap { it }
         // We need to verify the signature of the response and check that the payload is equal to what we expect.
         progressTracker.currentStep = VERIFYING_KEY
+        key?.let {
+            require(it == signedKeyForAccount.publicKey) {
+                "PublicKey returned by counter-party was not the key we requested an ownership claim for."
+            }
+        }
         verifySignedChallengeResponseSignature(signedKeyForAccount)
         progressTracker.currentStep = KEY_VERIFIED
         // Ensure the hash of both challenge response parameters matches the received hashed function


### PR DESCRIPTION
Added check that the publicKey returned by counter-party is the same as the publicKey we requested an ownership claim for before storing it. Without this check, the counter-party could potentially return a different key than what we requested an ownership claim for.

This new condition if covered by existing tests for the green-path. The red-path where the publicKey has been changed is not so easy to cover with tests since we can mock the flow easily.

Fix also applied to the corda 5 version of confidential identities: https://github.com/corda/corda5-confidential-identities/pull/19