### PR TITLE
ENT-6267 Add check to block signature verification bypass

### DIFF
--- a/workflows/src/main/kotlin/com/r3/corda/lib/ci/workflows/SignedKeyUtilities.kt
+++ b/workflows/src/main/kotlin/com/r3/corda/lib/ci/workflows/SignedKeyUtilities.kt
@@ -82,6 +82,10 @@ fun verifySignedChallengeResponseSignature(signedKeyForAccount: SignedKeyForAcco
     } catch (ex: SignatureException) {
         throw SignatureException("The signature on the object does not match that of the expected public key signature", ex)
     }
+    if (signedKeyForAccount.signedChallengeResponse.sig.by != signedKeyForAccount.publicKey) {
+        throw SignatureException("The public key used to sign the challenge response is not the same key " +
+                "returned as part of the SignedKeyForAccount")
+    }
 }
 
 /**


### PR DESCRIPTION
Previously RequestForKnownKey was updated the verify that the key returned by the counter party which we store mapped to that party was the same as the key we sent to the counter party for an ownership claim (see https://github.com/corda/confidential-identities/pull/14). This does not protect against the signature verification bypass which was originally reported however because the signature verification is done using another key. This PR verifies that the key returned as part of SignedKeyForAccount is the same as the key used to verify the signature on the returned challenge response. This check along with the previous check added will verify that the counter-party signed the challenge response with the same key that we requested the ownership claim for.