### PR TITLE
INFRA-2059: use correct snyk location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         GRADLE_USER_HOME = "/host_tmp/gradle"
         EXECUTOR_NUMBER = "${env.EXECUTOR_NUMBER}"
         MAVEN_LOCAL_PUBLISH = "${env.WORKSPACE}/${mavenLocal}"
-        SNYK_TOKEN  = credentials("c4-sdk-snyk")
+        SNYK_TOKEN  = credentials('c4-ent-snyk-api-token-secret')
     }
 
     stages {


### PR DESCRIPTION
- use correct credentials ID so as snyk scans get promoted to the Ent location of the snyk server (previously pushing data to C4 OS org which was incorrect) 