### PR TITLE
ES-770: Update Jenkinsfile to add cron to build project regularly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,11 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
     }
 
+    triggers {
+        cron (isReleaseBranch ? 'H 0 * * 1,4' : '')
+    }
+
+
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"


### PR DESCRIPTION
Add a cron job to this Jenkins file.

Build this project twice a week, Monday and Thursday, at a random minute (H) in the hour of midnight to distribute load.

WHile this project is supported there is not a lot of activity here, This change is to avoid situations where this project is not built for weeks/ months and build issues are only discovered on a release day.

