### PR TITLE
ES-1129: Ensure POM.xml generation is correct for Maven Central upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,26 @@ configure(publishProjects) { subproject ->
                 artifact tasks.javadocJar
 
                 pom {
-                    description = subproject.description
+                    name = subproject.name
+                    description = "confidential-identities ${subproject.name}"
+                    url = 'https://github.com/corda/confidential-identities'
+                    scm {
+                        url = 'https://github.com/corda/confidential-identities'
+                    }
+                    licenses {
+                        license {
+                            name = 'Apache-2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'R3'
+                            name = 'R3'
+                            email = 'dev@corda.net'
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
When publishing to `Maven Central`, a number of constraints in the pom.xml file must be satisfied. These include having correct license information / description / name etc.

This change ensures all these are present and thus that the project can correctly publish to `Maven Central.

New POM.xml format can be seen generated below

    <?xml version="1.0" encoding="UTF-8"?>
    <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
      <modelVersion>4.0.0</modelVersion>
      <groupId>com.r3.corda.lib.ci</groupId>
      <artifactId>ci-workflows</artifactId>
      <version>1.1.1</version>
      <name>workflows</name>
      <description>confidential-identities workflows</description>
      <url>https://github.com/corda/confidential-identities</url>
      <licenses>
        <license>
          <name>Apache-2.0</name>
          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
          <distribution>repo</distribution>
        </license>
      </licenses>
      <developers>
        <developer>
          <id>R3</id>
          <name>R3</name>
          <email>dev@corda.net</email>
        </developer>
      </developers>
      <scm>
        <url>https://github.com/corda/confidential-identities</url>
      </scm>
    </project>
