### PR TITLE
ES-1852: Update constants.properties to use 4.12HC02

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -5,7 +5,7 @@ versionSuffix=SNAPSHOT
 confidentialIdReleaseGroup=com.r3.corda.lib.ci
 
 cordaReleaseGroup=net.corda
-cordaReleaseVersion=4.12-HC01
+cordaReleaseVersion=4.12-HC02
 cordaPlatformVersion=14
 cordaGradlePluginsVersion=5.1.1
 kotlinVersion=1.9.0


### PR DESCRIPTION
Depend on corda `HC02` for the release/1.2 branch 