### PR TITLE
ES-2125: fix Jenkins logic issue causing gitID to be appended to version in release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
 boolean isReleaseTag = (env.TAG_NAME =~ /^release-.*$/)
 boolean isRelease = isReleaseTag
-String publishOptions = isReleaseBranch ? "-s --info" : "--no-daemon -s -PversionFromGit"
+String publishOptions = (isReleaseBranch || isReleaseTag) ? "-s --info" : "--no-daemon -s -PversionFromGit"
 
 pipeline {
     agent { label 'standard' }


### PR DESCRIPTION
Same issue as https://github.com/corda/r3-libs/pull/17 & https://github.com/corda/ledger-graph/pull/108

Fix Jenkins logic issue discovered during the release process.

Previous logic is incorrect as it would result in artifacts from tag builds being versioning with a git commit hash suffix.
i.e. 1.4-RC04-<CommitID>. This should never be used for tag builds.

Updated logic ensures that the git suffix is only used for PRs or feature branches.

Note: not blocking the current release, I've made the needed changes directly on the tag, but this should go back to the release branch to ensure no issues on later releases.