### PR TITLE
ES-2458: 4.12 GA post release actions

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -5,7 +5,7 @@ versionSuffix=SNAPSHOT
 confidentialIdReleaseGroup=com.r3.corda.lib.ci
 
 cordaReleaseGroup=net.corda
-cordaReleaseVersion=4.12-RC02
+cordaReleaseVersion=4.12
 cordaPlatformVersion=140
 cordaGradlePluginsVersion=5.1.1
 kotlinVersion=1.9.0


### PR DESCRIPTION
Post Release actions - Pin internal dependencies to GA versions. Please note these versions have already been released via tag creation but this PR is now committing the needed changes back to the release branch.