### PR TITLE
ENT-12428,ENT-12430 - Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
 }
 
 plugins {
-    id "org.ajoberstar.grgit" version "4.0.0"
+    id "org.ajoberstar.grgit" version "4.1.1"
 }
 
 apply plugin: 'net.corda.plugins.cordapp'

--- a/constants.properties
+++ b/constants.properties
@@ -5,7 +5,7 @@ versionSuffix=SNAPSHOT
 confidentialIdReleaseGroup=com.r3.corda.lib.ci
 
 cordaReleaseGroup=net.corda
-cordaReleaseVersion=4.12
+cordaReleaseVersion=4.12.4-RC01
 cordaPlatformVersion=140
 cordaGradlePluginsVersion=5.1.1
 kotlinVersion=1.9.0


### PR DESCRIPTION
Updated to build against Corda 4.12.4, which fixes a security vulnerability.
Also updated the version of org.ajoberstar.grgit to the latest available 4.x version, since 4.0.0 is apparently no longer available.