### PR TITLE
ENT-12854 - Updated Corda version

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -5,7 +5,7 @@ versionSuffix=SNAPSHOT
 confidentialIdReleaseGroup=com.r3.corda.lib.ci
 
 cordaReleaseGroup=net.corda
-cordaReleaseVersion=4.12.4-RC01
+cordaReleaseVersion=4.12.5
 cordaPlatformVersion=140
 cordaGradlePluginsVersion=5.1.3
 kotlinVersion=1.9.0


### PR DESCRIPTION
Updated Corda version to a released version. Missed this with the previous dependency updates.