### PR TITLE
ENT-15968 : Update cordaReleaseVersion to SNAPSHOT version

### DIFF
--- a/constants.properties
+++ b/constants.properties
@@ -5,7 +5,7 @@ versionSuffix=SNAPSHOT
 confidentialIdReleaseGroup=com.r3.corda.lib.ci
 
 cordaReleaseGroup=net.corda
-cordaReleaseVersion=4.12.5
+cordaReleaseVersion=4.12-SNAPSHOT
 cordaPlatformVersion=140
 cordaGradlePluginsVersion=5.1.3
 kotlinVersion=1.9.0


### PR DESCRIPTION
This PR updates cordaVersion and enterpriseVersion from '4.12.5' to '4.12-SNAPSHOT' , so it gets latest changes from ENT 4.12 and snyk reports correct vulnerability reports.